### PR TITLE
feat: Update app name to 'Tentwenty Task' on Android and iOS

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">tentwenty_assignment</string>
+    <string name="app_name">Tentwenty Task</string>
 </resources>

--- a/ios/tentwenty_assignment/Info.plist
+++ b/ios/tentwenty_assignment/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>tentwenty_assignment</string>
+	<string>Tentwenty Task</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Changed the app name from 'tentwenty_assignment' to 'Tentwenty Task' in both Android strings.xml and iOS Info.plist to ensure consistent branding across platforms.