### PR TITLE
chore: Add pre-push hook to run lint and format

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+yarn lint-format


### PR DESCRIPTION
Introduces a Husky pre-push hook that runs 'yarn lint-format' to ensure code quality before pushing changes.