### PR TITLE
feat: Add WatchMovieDetailScreen and navigation integration

### DIFF
--- a/src/components/MoviesList/MoviesList.tsx
+++ b/src/components/MoviesList/MoviesList.tsx
@@ -1,10 +1,12 @@
 import { FC } from 'react';
 import { FlatList, StyleProp, View, ViewStyle } from 'react-native';
 import { ActivityIndicator, Text } from 'react-native-paper';
+import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { MovieCard } from './components/MovieCard';
 
 import { useTheme } from '@tentwenty-tech/theme';
 
+import { WatchStackParamList } from '~/navigation/stack';
 import { IUpcomingMovies } from '~/screens/Watch';
 
 type MoviesListProps = {
@@ -26,6 +28,7 @@ export const MoviesList: FC<MoviesListProps> = ({
   numberOfLines
 }) => {
   const theme = useTheme();
+  const navigation = useNavigation<NavigationProp<WatchStackParamList>>();
 
   if (isLoading && data.length === 0) {
     return (
@@ -52,6 +55,11 @@ export const MoviesList: FC<MoviesListProps> = ({
             style
           ]}
           numberOfLines={numberOfLines}
+          onPress={() => {
+            navigation.navigate('WatchMovieDetailScreen', {
+              movie: item
+            });
+          }}
         />
       )}
       maxToRenderPerBatch={20}

--- a/src/navigation/stack/WatchStack/WatchStack.tsx
+++ b/src/navigation/stack/WatchStack/WatchStack.tsx
@@ -1,7 +1,8 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { WatchStackParamList } from './types';
 
-import { WatchDashboardScreen, WatchSearchScreen } from '~/screens/Watch';
+import { AppHeader } from '~/components';
+import { WatchDashboardScreen, WatchMovieDetailScreen, WatchSearchScreen } from '~/screens/Watch';
 
 const Stack = createNativeStackNavigator<WatchStackParamList>();
 export const WatchStack = () => {
@@ -9,6 +10,14 @@ export const WatchStack = () => {
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name='WatchDashboardScreen' component={WatchDashboardScreen} />
       <Stack.Screen name='WatchSearchScreen' component={WatchSearchScreen} />
+      <Stack.Screen
+        name='WatchMovieDetailScreen'
+        component={WatchMovieDetailScreen}
+        options={{
+          headerShown: true,
+          header: ({ navigation }) => <AppHeader title='Watch' hideSearchButton navigation={navigation as any} />
+        }}
+      />
     </Stack.Navigator>
   );
 };

--- a/src/navigation/stack/WatchStack/types.ts
+++ b/src/navigation/stack/WatchStack/types.ts
@@ -5,4 +5,7 @@ export type WatchStackParamList = {
   WatchSearchScreen: {
     upcomingMovies: IUpcomingMovies['results'];
   };
+  WatchMovieDetailScreen: {
+    movie: IUpcomingMovies['results'][number];
+  };
 };

--- a/src/navigation/tabNavigator/BottomTabBar.tsx
+++ b/src/navigation/tabNavigator/BottomTabBar.tsx
@@ -3,13 +3,25 @@ import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Text } from 'react-native-paper';
 import { enableScreens } from 'react-native-screens';
 import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+import { getFocusedRouteNameFromRoute } from '@react-navigation/native';
 
 import { IconDashboard, IconMediaLibrary, IconMore, IconWatch } from '@tentwenty-tech/icons';
 
 import { useTheme } from '~/hooks/useTheme';
 
+const hideTabBarRoutes = ['WatchMovieDetailScreen'];
+
 export const BottomTabBar: React.FC<BottomTabBarProps> = ({ state, descriptors, navigation }) => {
   const theme = useTheme();
+
+  // Check if WatchMovieDetailScreen is focused
+  const currentRoute = state.routes[state.index];
+  const focusedRouteName = getFocusedRouteNameFromRoute(currentRoute);
+
+  // Hide tab bar if on WatchMovieDetailScreen
+  if (currentRoute.name === 'WatchStack' && hideTabBarRoutes.includes(focusedRouteName ?? '')) {
+    return null;
+  }
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.lightGray }]}>

--- a/src/screens/Watch/WatchMovieDetailScreen/WatchMovieDetailScreen.tsx
+++ b/src/screens/Watch/WatchMovieDetailScreen/WatchMovieDetailScreen.tsx
@@ -1,0 +1,10 @@
+import { FC } from 'react';
+import { View } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { WatchStackParamList } from '~/navigation/stack';
+
+type WatchMovieDetailScreenProps = NativeStackScreenProps<WatchStackParamList, 'WatchMovieDetailScreen'>;
+export const WatchMovieDetailScreen: FC<WatchMovieDetailScreenProps> = ({}) => {
+  return <View />;
+};

--- a/src/screens/Watch/WatchMovieDetailScreen/index.ts
+++ b/src/screens/Watch/WatchMovieDetailScreen/index.ts
@@ -1,0 +1,1 @@
+export { WatchMovieDetailScreen } from './WatchMovieDetailScreen';

--- a/src/screens/Watch/index.ts
+++ b/src/screens/Watch/index.ts
@@ -1,3 +1,4 @@
+export type { IUpcomingMovies } from './types';
 export * from './WatchDashboardScreen';
 export * from './WatchSearchScreen';
-export type { IUpcomingMovies } from './types';
+export * from './WatchMovieDetailScreen';


### PR DESCRIPTION
Introduces the WatchMovieDetailScreen and integrates it into the WatchStack navigator. Updates MoviesList to navigate to the detail screen on movie card press, adds route typing, and hides the bottom tab bar when the detail screen is focused.