### PR TITLE
feat: Add YouTube trailer video player to Watch stack

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1740,6 +1740,35 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - react-native-webview (13.15.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - React-NativeModulesApple (0.80.2):
     - boost
     - DoubleConversion
@@ -2680,6 +2709,7 @@ DEPENDENCIES:
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
+  - react-native-webview (from `../node_modules/react-native-webview`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -2811,6 +2841,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
+  react-native-webview:
+    :path: "../node_modules/react-native-webview"
   React-NativeModulesApple:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios"
   React-oscompat:
@@ -2933,6 +2965,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 7018c5b7da5b13ed22fe55dae51d50187a00b2d7
   React-microtasksnativemodule: 8ff9cb220a8efa625b5885996bd69e69db9edf02
   react-native-safe-area-context: 68d1363b8354472a961aa6861ba8451beaf9a810
+  react-native-webview: 9a8ea59197aa76145b8ce72aa3eea69f1e89dd38
   React-NativeModulesApple: 37c08c3c54db55854de816b0df0f3683832be35a
   React-oscompat: 56d6de59f9ae95cd006a1c40be2cde83bc06a4e1
   React-perflogger: 4008bd05a8b6c157b06608c0ea0b8bd5d9c5e6c9

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "react-native-screens": "^4.13.1",
     "react-native-svg": "^15.12.0",
     "react-native-vector-icons": "^10.2.0",
-    "react-native-worklets": "^0.4.0"
+    "react-native-webview": "^13.15.0",
+    "react-native-worklets": "^0.4.0",
+    "react-native-youtube-iframe": "^2.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/navigation/stack/WatchStack/WatchStack.tsx
+++ b/src/navigation/stack/WatchStack/WatchStack.tsx
@@ -2,7 +2,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { WatchStackParamList } from './types';
 
 import { AppHeader } from '~/components';
-import { WatchDashboardScreen, WatchMovieDetailScreen, WatchSearchScreen } from '~/screens/Watch';
+import { VideoPlayerScreen, WatchDashboardScreen, WatchMovieDetailScreen, WatchSearchScreen } from '~/screens/Watch';
 
 const Stack = createNativeStackNavigator<WatchStackParamList>();
 export const WatchStack = () => {
@@ -16,6 +16,15 @@ export const WatchStack = () => {
         options={{
           headerShown: false,
           header: ({ navigation }) => <AppHeader title='Watch' hideSearchButton navigation={navigation as any} />
+        }}
+      />
+      <Stack.Screen
+        name='VideoPlayerScreen'
+        component={VideoPlayerScreen}
+        options={{
+          headerShown: false,
+          presentation: 'fullScreenModal',
+          gestureEnabled: false
         }}
       />
     </Stack.Navigator>

--- a/src/navigation/stack/WatchStack/types.ts
+++ b/src/navigation/stack/WatchStack/types.ts
@@ -8,4 +8,8 @@ export type WatchStackParamList = {
   WatchMovieDetailScreen: {
     movie: IUpcomingMovies['results'][number];
   };
+  VideoPlayerScreen: {
+    videoKey: string;
+    movieTitle: string;
+  };
 };

--- a/src/navigation/tabNavigator/BottomTabBar.tsx
+++ b/src/navigation/tabNavigator/BottomTabBar.tsx
@@ -9,7 +9,7 @@ import { IconDashboard, IconMediaLibrary, IconMore, IconWatch } from '@tentwenty
 
 import { useTheme } from '~/hooks/useTheme';
 
-const hideTabBarRoutes = ['WatchMovieDetailScreen'];
+const hideTabBarRoutes = ['WatchMovieDetailScreen', 'VideoPlayerScreen'];
 
 export const BottomTabBar: React.FC<BottomTabBarProps> = ({ state, descriptors, navigation }) => {
   const theme = useTheme();

--- a/src/screens/Watch/VideoPlayerScreen/VideoPlayerScreen.tsx
+++ b/src/screens/Watch/VideoPlayerScreen/VideoPlayerScreen.tsx
@@ -1,0 +1,118 @@
+import { FC, useCallback, useRef, useState } from 'react';
+import { StatusBar, StyleSheet, useWindowDimensions, View } from 'react-native';
+import { showMessage } from 'react-native-flash-message';
+import { ActivityIndicator, Appbar } from 'react-native-paper';
+import YoutubePlayer from 'react-native-youtube-iframe';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { useTheme } from '~/hooks/useTheme';
+import { WatchStackParamList } from '~/navigation/stack';
+
+type VideoPlayerScreenProps = NativeStackScreenProps<WatchStackParamList, 'VideoPlayerScreen'>;
+
+export const VideoPlayerScreen: FC<VideoPlayerScreenProps> = ({ navigation, route }) => {
+  const { height } = useWindowDimensions();
+  const theme = useTheme();
+  const { videoKey, movieTitle } = route.params;
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+  const playerRef = useRef<typeof YoutubePlayer>(null);
+
+  const onStateChange = useCallback(
+    (state: string) => {
+      if (state === 'ended') {
+        // Auto-close when video ends
+        navigation.goBack();
+        setIsPlaying(false);
+      }
+    },
+    [navigation]
+  );
+
+  const handleDone = () => {
+    navigation.goBack();
+  };
+
+  const onError = useCallback(
+    (error: string) => {
+      showMessage({
+        message: 'Video Error',
+        description: 'Unable to play the trailer. Please try again later.',
+        type: 'danger'
+      });
+    },
+    [navigation]
+  );
+
+  return (
+    <View style={styles.container}>
+      <StatusBar barStyle='light-content' backgroundColor='black' />
+
+      <Appbar.Header style={styles.header}>
+        <Appbar.Content title={`${movieTitle} - Trailer`} titleStyle={styles.headerTitle} />
+        <Appbar.Action icon='close' iconColor={theme.colors.white} onPress={handleDone} />
+      </Appbar.Header>
+
+      <View style={styles.playerContainer}>
+        {!isReady && (
+          <ActivityIndicator
+            size='large'
+            color={theme.colors.white}
+            style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, zIndex: 1000 }}
+            animating={true}
+          />
+        )}
+        <YoutubePlayer
+          ref={playerRef}
+          height={isReady ? height * 0.8 : 0}
+          width='100%'
+          play={isPlaying}
+          videoId={videoKey}
+          onChangeState={onStateChange}
+          onReady={() => {
+            setIsPlaying(true);
+            setIsReady(true);
+          }}
+          contentScale={0.8}
+          onError={onError}
+          forceAndroidAutoplay
+          initialPlayerParams={{
+            loop: false,
+            controls: true,
+            showClosedCaptions: true,
+            modestbranding: true,
+            rel: false
+          }}
+          webViewProps={{
+            injectedJavaScript: `
+            var element = document.getElementsByClassName('container')[0];
+            element.style.position = 'unset';
+            true;
+          `
+          }}
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'black'
+  },
+  header: {
+    backgroundColor: 'rgba(0, 0, 0, 0.8)',
+    elevation: 0
+  },
+  headerTitle: {
+    color: 'white',
+    fontSize: 16
+  },
+  playerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'black'
+  }
+});

--- a/src/screens/Watch/VideoPlayerScreen/index.ts
+++ b/src/screens/Watch/VideoPlayerScreen/index.ts
@@ -1,0 +1,1 @@
+export { VideoPlayerScreen } from './VideoPlayerScreen';

--- a/src/screens/Watch/WatchMovieDetailScreen/WatchMovieDetailScreen.tsx
+++ b/src/screens/Watch/WatchMovieDetailScreen/WatchMovieDetailScreen.tsx
@@ -6,6 +6,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import dayjs from 'dayjs';
 import { GenreTag } from './components/GenreTag';
 import { MovieDetailBackgroundImage } from './components/MovieDetailBackgroundImage';
+import { useMovieVideos } from './hooks/useMovieVideos';
 import useWatchMovieDetail from './hooks/useWatchMovieDetail';
 import { genresColors } from './utils/genresColors';
 import { useStyles } from './WatchMovieDetailScreen.styles';
@@ -23,7 +24,16 @@ export const WatchMovieDetailScreen: FC<WatchMovieDetailScreenProps> = ({ naviga
     movie: { id: movieID }
   } = route.params;
   const { movie, isLoading } = useWatchMovieDetail({ movieID });
-  console.log(movie);
+  const { trailerKey } = useMovieVideos({ movieID });
+
+  const handleWatchTrailer = () => {
+    if (trailerKey) {
+      navigation.navigate('VideoPlayerScreen', {
+        videoKey: trailerKey,
+        movieTitle: movie?.title || 'Movie Trailer'
+      });
+    }
+  };
 
   if (isLoading)
     return (
@@ -66,7 +76,13 @@ export const WatchMovieDetailScreen: FC<WatchMovieDetailScreenProps> = ({ naviga
           <Button mode='contained' style={styles.getTicketsButton} labelStyle={styles.buttonText}>
             Get Tickets
           </Button>
-          <Button mode='outlined' style={styles.watchTrailerButton} labelStyle={styles.buttonText} icon='play'>
+          <Button
+            mode='outlined'
+            style={styles.watchTrailerButton}
+            labelStyle={styles.buttonText}
+            icon='play'
+            onPress={handleWatchTrailer}
+            disabled={!trailerKey}>
             Watch Trailer
           </Button>
         </View>

--- a/src/screens/Watch/WatchMovieDetailScreen/hooks/useMovieVideos.ts
+++ b/src/screens/Watch/WatchMovieDetailScreen/hooks/useMovieVideos.ts
@@ -1,0 +1,27 @@
+import { IMovieVideo } from '../../types';
+
+import { useAxios } from '~/config/Axios';
+
+export const useMovieVideos = ({ movieID }: { movieID: number }) => {
+  const [{ data, loading, error }] = useAxios<IMovieVideo>({
+    method: 'GET',
+    url: `/movie/${movieID}/videos`
+  });
+
+  // Find the first official trailer from YouTube
+  const getTrailerKey = () => {
+    if (!data?.results) return null;
+
+    const trailer = data.results.find((video) => video.site === 'YouTube' && video.type === 'Trailer' && video.official === true);
+
+    // Fallback to any YouTube trailer if no official one found
+    return trailer?.key || data.results.find((video) => video.site === 'YouTube')?.key || null;
+  };
+
+  return {
+    videos: data,
+    trailerKey: getTrailerKey(),
+    isLoading: loading,
+    error
+  };
+};

--- a/src/screens/Watch/index.ts
+++ b/src/screens/Watch/index.ts
@@ -2,3 +2,4 @@ export type { IUpcomingMovies, IMovieDetail } from './types';
 export * from './WatchDashboardScreen';
 export * from './WatchSearchScreen';
 export * from './WatchMovieDetailScreen';
+export * from './VideoPlayerScreen';

--- a/src/screens/Watch/types.ts
+++ b/src/screens/Watch/types.ts
@@ -72,3 +72,19 @@ export type IMovieDetail = {
   vote_average: number;
   vote_count: number;
 };
+
+export type IMovieVideo = {
+  id: number;
+  results: Array<{
+    iso_639_1: string;
+    iso_3166_1: string;
+    name: string;
+    key: string;
+    site: string;
+    size: number;
+    type: string;
+    official: boolean;
+    published_at: Date;
+    id: string;
+  }>;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5407,6 +5407,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"events@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: 10c0/d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
+  languageName: node
+  linkType: hard
+
 "execa@npm:^5.0.0":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
@@ -6273,7 +6280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"invariant@npm:^2.2.4":
+"invariant@npm:2.2.4, invariant@npm:^2.2.4":
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
   dependencies:
@@ -9111,6 +9118,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-webview@npm:^13.15.0":
+  version: 13.15.0
+  resolution: "react-native-webview@npm:13.15.0"
+  dependencies:
+    escape-string-regexp: "npm:^4.0.0"
+    invariant: "npm:2.2.4"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/29b8ad4c1c8623c62e868893e829d20ef1ab51b38f44d0f422e0c19df9d8747ae25d1fcceec4e6d78106f263dce66b7984eeb12c0e5046c7c898b81673b0b6d6
+  languageName: node
+  linkType: hard
+
 "react-native-worklets@npm:^0.4.0":
   version: 0.4.0
   resolution: "react-native-worklets@npm:0.4.0"
@@ -9130,6 +9150,25 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/768ef67c1701f2354cda48f44ea337fd57cfa463acdeb65dc7808461aaa92a56c0f33d5ac6880d6d22cc5765b6751caa45307402b20f6575d3183b7029e3567a
+  languageName: node
+  linkType: hard
+
+"react-native-youtube-iframe@npm:^2.3.0":
+  version: 2.4.1
+  resolution: "react-native-youtube-iframe@npm:2.4.1"
+  dependencies:
+    events: "npm:^3.3.0"
+  peerDependencies:
+    react: ">=16.8.6"
+    react-native: ">=0.60"
+    react-native-web-webview: ">=1.0.2"
+    react-native-webview: ">=7.0.0"
+  peerDependenciesMeta:
+    react-native-web-webview:
+      optional: true
+    react-native-webview:
+      optional: true
+  checksum: 10c0/966fe52c3a298b01e58259d3f9bf9c94d8764ec7452918f9e0b2cc7f977461b8d9d8e3023a1b5fcc6ca0d470ec0ea3cc4dc1714a6e6ae62b3b16e552faf8deda
   languageName: node
   linkType: hard
 
@@ -10357,7 +10396,9 @@ __metadata:
     react-native-svg: "npm:^15.12.0"
     react-native-svg-transformer: "npm:^1.5.1"
     react-native-vector-icons: "npm:^10.2.0"
+    react-native-webview: "npm:^13.15.0"
     react-native-worklets: "npm:^0.4.0"
+    react-native-youtube-iframe: "npm:^2.3.0"
     react-test-renderer: "npm:19.1.0"
     typescript: "npm:5.0.4"
   languageName: unknown


### PR DESCRIPTION
Introduced a VideoPlayerScreen for playing YouTube trailers using react-native-youtube-iframe and react-native-webview. Updated WatchMovieDetailScreen to allow users to watch trailers, added a custom hook to fetch trailer video keys, and adjusted navigation and tab bar logic to support the new screen. Updated types and dependencies accordingly.