### PR TITLE
faet: Add WatchSelectDateTimeScreen for movie ticket selection

### DIFF
--- a/src/navigation/stack/WatchStack/WatchStack.tsx
+++ b/src/navigation/stack/WatchStack/WatchStack.tsx
@@ -2,7 +2,13 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { WatchStackParamList } from './types';
 
 import { AppHeader } from '~/components';
-import { VideoPlayerScreen, WatchDashboardScreen, WatchMovieDetailScreen, WatchSearchScreen } from '~/screens/Watch';
+import {
+  VideoPlayerScreen,
+  WatchDashboardScreen,
+  WatchMovieDetailScreen,
+  WatchSearchScreen,
+  WatchSelectDateTimeScreen
+} from '~/screens/Watch';
 
 const Stack = createNativeStackNavigator<WatchStackParamList>();
 export const WatchStack = () => {
@@ -31,6 +37,13 @@ export const WatchStack = () => {
           headerShown: false,
           presentation: 'fullScreenModal',
           gestureEnabled: false
+        }}
+      />
+      <Stack.Screen
+        name='WatchSelectDateTimeScreen'
+        component={WatchSelectDateTimeScreen}
+        options={{
+          headerShown: false
         }}
       />
     </Stack.Navigator>

--- a/src/navigation/stack/WatchStack/types.ts
+++ b/src/navigation/stack/WatchStack/types.ts
@@ -12,4 +12,7 @@ export type WatchStackParamList = {
     videoKey: string;
     movieTitle: string;
   };
+  WatchSelectDateTimeScreen: {
+    movie: IUpcomingMovies['results'][number];
+  };
 };

--- a/src/navigation/tabNavigator/BottomTabBar.tsx
+++ b/src/navigation/tabNavigator/BottomTabBar.tsx
@@ -4,12 +4,17 @@ import { Text } from 'react-native-paper';
 import { enableScreens } from 'react-native-screens';
 import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { getFocusedRouteNameFromRoute } from '@react-navigation/native';
+import { WatchStackParamList } from '../stack';
 
 import { IconDashboard, IconMediaLibrary, IconMore, IconWatch } from '@tentwenty-tech/icons';
 
 import { useTheme } from '~/hooks/useTheme';
 
-const hideTabBarRoutes = ['WatchMovieDetailScreen', 'VideoPlayerScreen'];
+const hideTabBarRoutes: Array<keyof WatchStackParamList> = [
+  'WatchMovieDetailScreen',
+  'VideoPlayerScreen',
+  'WatchSelectDateTimeScreen'
+];
 
 export const BottomTabBar: React.FC<BottomTabBarProps> = ({ state, descriptors, navigation }) => {
   const theme = useTheme();
@@ -19,7 +24,7 @@ export const BottomTabBar: React.FC<BottomTabBarProps> = ({ state, descriptors, 
   const focusedRouteName = getFocusedRouteNameFromRoute(currentRoute);
 
   // Hide tab bar if on WatchMovieDetailScreen
-  if (currentRoute.name === 'WatchStack' && hideTabBarRoutes.includes(focusedRouteName ?? '')) {
+  if (currentRoute.name === 'WatchStack' && hideTabBarRoutes.includes(focusedRouteName as keyof WatchStackParamList)) {
     return null;
   }
 

--- a/src/screens/Watch/WatchMovieDetailScreen/WatchMovieDetailScreen.tsx
+++ b/src/screens/Watch/WatchMovieDetailScreen/WatchMovieDetailScreen.tsx
@@ -35,6 +35,12 @@ export const WatchMovieDetailScreen: FC<WatchMovieDetailScreenProps> = ({ naviga
     }
   };
 
+  const handleGetTickets = () => {
+    navigation.navigate('WatchSelectDateTimeScreen', {
+      movie: route.params.movie
+    });
+  };
+
   if (isLoading)
     return (
       <View style={styles.container}>
@@ -73,7 +79,7 @@ export const WatchMovieDetailScreen: FC<WatchMovieDetailScreenProps> = ({ naviga
         <Text style={styles.releaseDate}>{`In Theaters ${dayjs(movie.release_date).format('MMMM D, YYYY')}`}</Text>
 
         <View style={styles.buttonsContainer}>
-          <Button mode='contained' style={styles.getTicketsButton} labelStyle={styles.buttonText}>
+          <Button mode='contained' style={styles.getTicketsButton} labelStyle={styles.buttonText} onPress={handleGetTickets}>
             Get Tickets
           </Button>
           <Button

--- a/src/screens/Watch/WatchSelectDateTimeScreen/WatchSelectDateTimeScreen.styles.ts
+++ b/src/screens/Watch/WatchSelectDateTimeScreen/WatchSelectDateTimeScreen.styles.ts
@@ -1,0 +1,147 @@
+import { StyleSheet, useWindowDimensions } from 'react-native';
+
+import { useTheme } from '~/hooks/useTheme';
+
+export const useStyles = () => {
+  const theme = useTheme();
+  const { width } = useWindowDimensions();
+
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.lightGray
+    },
+    content: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center'
+    },
+    dateSectionContainer: {},
+    sectionTitle: {
+      color: theme.colors.black,
+      paddingHorizontal: theme.spacing.s
+    },
+    dateScrollView: {
+      flexGrow: 0
+    },
+    dateContainer: {
+      flexGrow: 0,
+      paddingHorizontal: theme.spacing.s
+    },
+    dateCard: {
+      backgroundColor: theme.colors.white,
+      borderRadius: 10,
+      paddingVertical: 8,
+      paddingHorizontal: 16,
+      marginRight: 8,
+      alignItems: 'center',
+      justifyContent: 'center',
+      minWidth: 70
+    },
+    selectedDateCard: {
+      backgroundColor: theme.colors.skyBlue
+    },
+    dateText: {
+      fontSize: 14,
+      fontWeight: '500',
+      color: theme.colors.black
+    },
+    selectedDateText: {
+      color: theme.colors.white
+    },
+    showtimesContainer: {
+      flexGrow: 0,
+      marginTop: theme.spacing.l,
+      paddingHorizontal: theme.spacing.s
+    },
+    showtimesContainerContent: {
+      flexGrow: 0,
+      paddingRight: theme.spacing.s
+    },
+    showtimeItemContainer: {
+      marginRight: theme.spacing.s
+    },
+    showtimeCinemaHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: theme.spacing.xxxs
+    },
+    showtimeTime: {
+      color: theme.colors.black
+    },
+    showtimeCinema: {
+      marginLeft: theme.spacing.xxs
+    },
+    seatCardContainer: {
+      backgroundColor: theme.colors.white,
+      borderRadius: theme.spacing.xs,
+      marginBottom: theme.spacing.xxxs,
+      padding: theme.spacing.s,
+      shadowColor: '#000',
+      shadowOffset: {
+        width: 0,
+        height: 2
+      },
+      shadowOpacity: 0.1,
+      shadowRadius: 4,
+      elevation: 3,
+      width: width * 0.7 - theme.spacing.s
+    },
+    selectedSeatCardContainer: {
+      backgroundColor: theme.colors.lightGray,
+      borderWidth: 2,
+      borderColor: theme.colors.skyBlue
+    },
+    seatGrid: {
+      alignItems: 'center',
+      marginVertical: theme.spacing.xs
+    },
+    seatRow: {
+      flexDirection: 'row',
+      marginBottom: theme.spacing.xxxs
+    },
+    seat: {
+      width: theme.spacing.xxxs,
+      height: theme.spacing.xxxs,
+      borderRadius: 3,
+      marginHorizontal: 1,
+      backgroundColor: theme.colors.skyBlue
+    },
+    occupiedSeat: {
+      backgroundColor: theme.colors.mutedLavender
+    },
+    selectedSeat: {
+      backgroundColor: theme.colors.teal
+    },
+    showtimeFooter: {
+      flexDirection: 'row',
+      alignItems: 'center'
+    },
+    priceText: {
+      color: theme.colors.mutedLavender
+    },
+    priceTextValue: {
+      color: theme.colors.black,
+      fontWeight: 'bold',
+      marginHorizontal: theme.spacing.xxxs,
+      marginTop: 2
+    },
+    bottomContainer: {
+      padding: 16,
+      backgroundColor: theme.colors.white
+    },
+    selectSeatsButton: {
+      borderRadius: 10,
+      paddingVertical: 6,
+      backgroundColor: theme.colors.skyBlue
+    },
+    selectSeatsButtonDisabled: {
+      backgroundColor: theme.colors.gray
+    },
+    buttonText: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: theme.colors.white
+    }
+  });
+};

--- a/src/screens/Watch/WatchSelectDateTimeScreen/WatchSelectDateTimeScreen.tsx
+++ b/src/screens/Watch/WatchSelectDateTimeScreen/WatchSelectDateTimeScreen.tsx
@@ -1,0 +1,216 @@
+import React, { useState } from 'react';
+import { Pressable, ScrollView, TouchableOpacity, View } from 'react-native';
+import { Button, Text } from 'react-native-paper';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import dayjs from 'dayjs';
+import { useStyles } from './WatchSelectDateTimeScreen.styles';
+
+import { AppHeader, AppStatusBar } from '~/components';
+import { WatchStackParamList } from '~/navigation/stack';
+
+type WatchSelectDateTimeScreenProps = NativeStackScreenProps<WatchStackParamList, 'WatchSelectDateTimeScreen'>;
+
+// Generate next 7 days for date selection
+const generateDates = () => {
+  const dates = [];
+  for (let i = 0; i < 7; i++) {
+    const date = dayjs().add(i, 'day');
+    dates.push({
+      id: i,
+      date: date.toDate(),
+      dayName: date.format('ddd'),
+      dayNumber: date.format('D'),
+      monthName: date.format('MMM'),
+      fullDate: date.format('YYYY-MM-DD')
+    });
+  }
+  return dates;
+};
+
+// Showtime data
+const showtimes = [
+  {
+    id: 1,
+    time: '12:30',
+    cinema: 'Cinetech + hall 1',
+    priceFrom: 50,
+    priceTo: 2500,
+    currency: '$'
+  },
+  {
+    id: 2,
+    time: '13:30',
+    cinema: 'Cinetech + hall 2',
+    priceFrom: 75,
+    priceTo: 3000,
+    currency: '$'
+  }
+];
+
+// Generate seat grid
+const generateSeatGrid = () => {
+  const rows = 12;
+  const seatsPerRow = 25;
+  const seats = [];
+
+  for (let row = 0; row < rows; row++) {
+    const rowSeats = [];
+    for (let seat = 0; seat < seatsPerRow; seat++) {
+      const seatNumber = row * seatsPerRow + seat;
+      let status = 'available'; // available, occupied, selected
+
+      // Randomly mark some seats as occupied for demo
+      if (Math.random() > 0.7) {
+        status = 'occupied';
+      }
+
+      rowSeats.push({
+        id: seatNumber,
+        row: row,
+        seat: seat,
+        status: status
+      });
+    }
+    seats.push(rowSeats);
+  }
+  return seats;
+};
+
+export const WatchSelectDateTimeScreen: React.FC<WatchSelectDateTimeScreenProps> = ({ navigation, route }) => {
+  const styles = useStyles();
+  const { movie } = route.params;
+
+  const [selectedDate, setSelectedDate] = useState<string>(generateDates()[0].fullDate);
+  const [selectedShowtime, setSelectedShowtime] = useState<number | null>(null);
+
+  const dates = generateDates();
+
+  const renderSeatGrid = () => {
+    const seatGrid = generateSeatGrid();
+
+    return (
+      <View style={styles.seatGrid}>
+        {seatGrid.map((row, rowIndex) => (
+          <View key={rowIndex} style={styles.seatRow}>
+            {row.map((seat) => (
+              <View
+                key={seat.id}
+                style={[
+                  styles.seat,
+                  seat.status === 'occupied' && styles.occupiedSeat,
+                  seat.status === 'selected' && styles.selectedSeat
+                ]}
+              />
+            ))}
+          </View>
+        ))}
+      </View>
+    );
+  };
+
+  const handleShowtimePress = (showtimeId: number) => {
+    setSelectedShowtime(showtimeId);
+  };
+
+  const renderShowtimeCard = (showtime: (typeof showtimes)[0]) => {
+    const isSelected = selectedShowtime === showtime.id;
+
+    return (
+      <Pressable key={showtime.id} style={styles.showtimeItemContainer} onPress={() => handleShowtimePress(showtime.id)}>
+        <View style={styles.showtimeCinemaHeader}>
+          <Text style={styles.showtimeTime} variant='bodyMedium'>
+            {showtime.time}
+          </Text>
+          <Text style={styles.showtimeCinema} variant='bodySmall'>
+            {showtime.cinema}
+          </Text>
+        </View>
+
+        <View style={[styles.seatCardContainer, isSelected && styles.selectedSeatCardContainer]}>{renderSeatGrid()}</View>
+
+        <View style={styles.showtimeFooter}>
+          <Text style={styles.priceText} variant='bodySmall'>
+            From
+          </Text>
+          <Text style={styles.priceTextValue} variant='bodySmall'>
+            {showtime.currency}
+            {showtime.priceFrom}
+          </Text>
+          <Text style={styles.priceText} variant='bodySmall'>
+            or
+          </Text>
+          <Text style={styles.priceTextValue} variant='bodySmall'>
+            {showtime.currency}
+            {showtime.priceTo}
+          </Text>
+          <Text style={styles.priceText} variant='bodySmall'>
+            bonus
+          </Text>
+        </View>
+      </Pressable>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <AppStatusBar barStyle='dark-content' />
+      <AppHeader
+        variant='center'
+        navigation={navigation as any}
+        title={movie.title}
+        description={`In Theaters ${dayjs(movie.release_date).format('MMMM D, YYYY')}`}
+      />
+
+      <View style={styles.content}>
+        {/* Date Selection */}
+        <View style={styles.dateSectionContainer}>
+          <Text style={styles.sectionTitle} variant='titleMedium'>
+            Date
+          </Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.dateScrollView}
+            contentContainerStyle={styles.dateContainer}>
+            {dates.map((dateItem) => (
+              <TouchableOpacity
+                key={dateItem.id}
+                onPress={() => setSelectedDate(dateItem.fullDate)}
+                disabled={selectedDate === dateItem.fullDate}
+                activeOpacity={0.8}
+                style={[styles.dateCard, selectedDate === dateItem.fullDate && styles.selectedDateCard]}>
+                <Text style={[styles.dateText, selectedDate === dateItem.fullDate && styles.selectedDateText]}>
+                  {dateItem.dayNumber} {dateItem.monthName}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+        </View>
+
+        {/* Showtimes */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.showtimesContainer}
+          contentContainerStyle={styles.showtimesContainerContent}>
+          {showtimes.map(renderShowtimeCard)}
+        </ScrollView>
+      </View>
+
+      {/* Bottom Button */}
+      <View style={styles.bottomContainer}>
+        <Button
+          mode='contained'
+          onPress={() => {
+            // Handle seat selection navigation
+            console.log('Select Seats pressed');
+          }}
+          disabled={!selectedShowtime || !selectedDate}
+          style={[styles.selectSeatsButton, (!selectedShowtime || !selectedDate) && styles.selectSeatsButtonDisabled]}
+          labelStyle={styles.buttonText}>
+          Select Seats
+        </Button>
+      </View>
+    </View>
+  );
+};

--- a/src/screens/Watch/WatchSelectDateTimeScreen/index.ts
+++ b/src/screens/Watch/WatchSelectDateTimeScreen/index.ts
@@ -1,0 +1,1 @@
+export { WatchSelectDateTimeScreen } from './WatchSelectDateTimeScreen';

--- a/src/screens/Watch/index.ts
+++ b/src/screens/Watch/index.ts
@@ -3,3 +3,4 @@ export * from './WatchDashboardScreen';
 export * from './WatchSearchScreen';
 export * from './WatchMovieDetailScreen';
 export * from './VideoPlayerScreen';
+export * from './WatchSelectDateTimeScreen';


### PR DESCRIPTION
Introduces the WatchSelectDateTimeScreen, allowing users to select a date and showtime for a movie. Updates navigation stack, types, and tab bar logic to support the new screen. Adds styles, screen implementation, and exports for the new feature. Also wires up the 'Get Tickets' button in WatchMovieDetailScreen to navigate to the new selection screen.